### PR TITLE
feat: cross-reference NPM and GTM variants in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Conviva's CDN supports Brotli and gzip compression. When the browser sends the a
 
 **Note:** Conviva CDN serves DPI sensors starting from version v1.5.5
 
+**Note**: For NPM-based integrations, refer to [Conviva JS DPI SDK (NPM)](https://github.com/Conviva/conviva-js-appanalytics) for guidelines. For Google Tag Manager–based integrations, refer to the [Conviva DPI JS SDK GTM template](https://tagmanager.google.com/gallery/#/owners/Conviva/templates/conviva-dpi-js-sdk-gtm).
+
 <!--eof-self-serve--> 
 ### 2. Initialization
 


### PR DESCRIPTION
## Summary

Add a Quick Start note in the script SDK README pointing users to the other two integration variants:

- **NPM** package — `@convivainc/conviva-js-appanalytics` ([Conviva JS DPI SDK](https://github.com/Conviva/conviva-js-appanalytics))
- **Google Tag Manager** template — [Conviva DPI JS SDK GTM template](https://tagmanager.google.com/gallery/#/owners/Conviva/templates/conviva-dpi-js-sdk-gtm)

This mirrors the cross-reference note that already exists in the NPM repo (which is being extended to include the GTM link in a parallel PR), so anyone landing on any of the three repos can discover the others.

## Change

`README.md`, Quick Start → Installation, immediately after the existing CDN-version note (so it sits inside the same self-serve block):

> **Note:** Conviva CDN serves DPI sensors starting from version v1.5.5
>
> **Note**: For NPM-based integrations, refer to [Conviva JS DPI SDK (NPM)](https://github.com/Conviva/conviva-js-appanalytics) for guidelines. For Google Tag Manager–based integrations, refer to the [Conviva DPI JS SDK GTM template](https://tagmanager.google.com/gallery/#/owners/Conviva/templates/conviva-dpi-js-sdk-gtm).

## Related

- Parallel PR in `conviva-js-appanalytics` adds the GTM link to the existing script-SDK cross-reference note: https://github.com/Conviva/conviva-js-appanalytics/pull/33

## Test plan

- [x] Markdown renders cleanly (link targets, em-dash, no broken anchors).
- [x] No existing content removed; only one paragraph added.
- [ ] Reviewer confirms the GTM gallery URL and NPM repo URL are the canonical links we want to advertise.